### PR TITLE
Fix bug with async request and props rerendering

### DIFF
--- a/src/ReactSelectize.ls
+++ b/src/ReactSelectize.ls
@@ -451,6 +451,7 @@ module.exports = create-class do
 
     # highlight-and-scroll-to-option :: Int, (a -> Void)? -> Void
     highlight-and-scroll-to-option: (index, callback = (->)) !->
+        index = 0 unless index
         uid = @props.uid @props.options[index]
         <~ @props.on-highlighted-uid-change uid
         option-element? = find-DOM-node @refs?["option-#{@uid-to-string uid}"]
@@ -492,7 +493,7 @@ module.exports = create-class do
     # select-highlighted-uid :: Int -> Void
     select-highlighted-uid: (anchor-index) !->
         return if @props.highlighted-uid == undefined
-        
+
         index = @option-index-from-uid @props.highlighted-uid
         return if typeof index != \number
 


### PR DESCRIPTION
the id is NaN because the component gets rerendered from props (passed by an async request from outside), and if the list changes the element is not there anymore and the highlighted id is null, manually setting it to 0 fixes the issue
